### PR TITLE
Add Google I/O Extended 2017 Embedded Widget

### DIFF
--- a/index.html
+++ b/index.html
@@ -69,6 +69,8 @@
       <li><a href="https://adg-berlin.slack.com/">Android Developer Group Berlin Slack</a> (<a href="https://adg-berlin.herokuapp.com">request invite</a>)<img src="http://adg-berlin.herokuapp.com/badge.svg" alt="slack-badge showing users online right now."></li>
       <li><a href="https://github.com/gdg-berlin-android">GDG Berlin Android on GitHub</a></li>
     </ul>
+    
+    <iframe src="https://events.google.com/io2017/embed" style="width:875px;height:450px" frameborder="0" allowfullscreen></iframe> 
 
     <div id="disclaimer">
     GDG Berlin Android is an independent group; our activities and the opinions expressed here should in no way be linked to Google, the corporation. 


### PR DESCRIPTION
As a preparation for the I/O extended session we are going to host somewhere, let us enthuse our audience with a teaser ...

[FAQ](https://events.google.com/io/widget/)