### PR TITLE
Replace heroku slack signup with slack link

### DIFF
--- a/index.html
+++ b/index.html
@@ -119,7 +119,7 @@
               <br><u>- beginners:</u> come by and ask us any question you have. We will help you regardless it is installing AndroidStudio or making VR app;
               <br><u>- experienced:</u> come by and share your knowledge and help our new Android fellows or ask questions to other experienced attendees, or just to work on your own projects.
               <br><br>There no strict rule. Just come by and let’s share a good time!
-              <br><br>We encourage you to join our Slack group “Android Developer Group Berlin”. Use our <a href="https://join.slack.com/t/adg-berlin/shared_invite/zt-1j6f5y2oh-A3Xf1VDTKDOTf55Ti_H5~g">our signup link</a> 
+              <br><br>We encourage you to join our Slack group “Android Developer Group Berlin”. Use our <a href="https://join.slack.com/t/adg-berlin/shared_invite/zt-1j6f5y2oh-A3Xf1VDTKDOTf55Ti_H5~g">signup link</a> 
               to join, and once on slack you can find #co-learning channel. There all attendees and organizers are encouraged to hang out.</p>
           </div>
           <div class="col-lg-4 section">

--- a/index.html
+++ b/index.html
@@ -37,7 +37,7 @@
              <li class="nav-item"><a class="nav-link" href="mailto:gdg-berlin-android-orga@googlegroups.com"><i class="far fa-envelope fa-lg"></i></a></li>
              <li class="nav-item"><a class="nav-link" href="https://www.meetup.com/GDG-Berlin-Android/">Events</a></li>
              <li class="nav-item"><a class="nav-link" href="https://twitter.com/berlindroid">Twitter</a></li>
-             <li class="nav-item"><a class="nav-link" href="https://adg-berlin.herokuapp.com">Slack</a></li>
+             <li class="nav-item"><a class="nav-link" href="https://join.slack.com/t/adg-berlin/shared_invite/zt-1j6f5y2oh-A3Xf1VDTKDOTf55Ti_H5~g">Slack</a></li>
              <li class="nav-item"><a class="nav-link" href="https://github.com/gdg-berlin-android">Github</a></li>
              <li class="nav-item"><a class="nav-link" href="https://goo.gl/forms/LKVnBINiIcyeeEfy2">Propose presentation</a></li>
            </ul>
@@ -70,7 +70,7 @@
               <div class="carousel-caption">
                 <h1>Our co-learning channel</h1>
                 <br>
-                <p><a class="btn btn-lg btn-primary" href="https://adg-berlin.herokuapp.com/" role="button">Learn more</a></p>
+                <p><a class="btn btn-lg btn-primary" href="https://join.slack.com/t/adg-berlin/shared_invite/zt-1j6f5y2oh-A3Xf1VDTKDOTf55Ti_H5~g" role="button">Learn more</a></p>
               </div>
             </div>
           </div>
@@ -119,8 +119,8 @@
               <br><u>- beginners:</u> come by and ask us any question you have. We will help you regardless it is installing AndroidStudio or making VR app;
               <br><u>- experienced:</u> come by and share your knowledge and help our new Android fellows or ask questions to other experienced attendees, or just to work on your own projects.
               <br><br>There no strict rule. Just come by and let’s share a good time!
-              <br><br>We encourage you to join our Slack group “Android Developer Group Berlin”. Visit <a href="https://adg-berlin.herokuapp.com">heroku</a> 
-              and there you can find #co-learning channel. There all attendees and organizers are encouraged to hang out.</p>
+              <br><br>We encourage you to join our Slack group “Android Developer Group Berlin”. Use our <a href="https://join.slack.com/t/adg-berlin/shared_invite/zt-1j6f5y2oh-A3Xf1VDTKDOTf55Ti_H5~g">our signup link</a> 
+              to join, and once on slack you can find #co-learning channel. There all attendees and organizers are encouraged to hang out.</p>
           </div>
           <div class="col-lg-4 section">
             <h6 class="font-italic">Yearly meetup</h6>
@@ -145,7 +145,7 @@
             <div class="col-md-6">
               <h6>Who we are</h6>
               <p class="post-body">We are the Berlin Google Developer Group (GDG) focused on Android development.
-                <br><br> Go <a href="https://adg-berlin.herokuapp.com/">here</a> to join the Android Developers Group Slack team.
+                <br><br> Go <a href="https://join.slack.com/t/adg-berlin/shared_invite/zt-1j6f5y2oh-A3Xf1VDTKDOTf55Ti_H5~g">here</a> to join the Android Developers Group Slack team.
                 <br>To contact the organizers write us an <a href="mailto:gdg-berlin-android-orga@googlegroups.com">email</a>.
               </p>
             </div>
@@ -172,7 +172,7 @@
              <ul>
                <li><a href="https://www.meetup.com/GDG-Berlin-Android/">Events</a></li>
                <li><a href="https://twitter.com/berlindroid">Twitter</a></li>
-               <li><a href="https://adg-berlin.herokuapp.com">Slack</a></li>
+               <li><a href="https://join.slack.com/t/adg-berlin/shared_invite/zt-1j6f5y2oh-A3Xf1VDTKDOTf55Ti_H5~g">Slack</a></li>
                <li><a href="https://github.com/gdg-berlin-android">Gitub</a></li>
              </ul>
            </div>
@@ -194,7 +194,7 @@
                <li><a class="py-2 d-md-inline-block" href="https://twitter.com/berlindroid"><i class="fab fa-twitter fa-lg"></i></a></li>
                <li><a class="py-2 d-md-inline-block" href="https://www.meetup.com/GDG-Berlin-Android/"><i class="fab fa-meetup fa-lg"></i></a></li>
                <li><a class="py-2 d-md-inline-block" href="https://github.com/gdg-berlin-android"><i class="fab fa-github fa-lg"></i></a></li>
-               <li><a class="py-2 d-md-inline-block" href="https://adg-berlin.herokuapp.com/"><i class="fab fa-slack-hash fa-lg"></i></a></li>
+               <li><a class="py-2 d-md-inline-block" href="https://join.slack.com/t/adg-berlin/shared_invite/zt-1j6f5y2oh-A3Xf1VDTKDOTf55Ti_H5~g"><i class="fab fa-slack-hash fa-lg"></i></a></li>
              </ul>
            </div>
          </div>


### PR DESCRIPTION
Heroku app seems to be broken, I have created an eternal signup link instead.