### PR TITLE
Update index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -37,7 +37,7 @@
              <li class="nav-item"><a class="nav-link" href="mailto:gdg-berlin-android-orga@googlegroups.com"><i class="far fa-envelope fa-lg"></i></a></li>
              <li class="nav-item"><a class="nav-link" href="https://www.meetup.com/GDG-Berlin-Android/">Events</a></li>
              <li class="nav-item"><a class="nav-link" href="https://androiddev.social/@berlindroid">Mastodon</a></li>
-             <li class="nav-item"><a class="nav-link" href="https://join.slack.com/t/adg-berlin/shared_invite/zt-1j6f5y2oh-A3Xf1VDTKDOTf55Ti_H5~g">Slack</a></li>
+             <li class="nav-item"><a class="nav-link" href="https://join.slack.com/t/adg-berlin/shared_invite/zt-20sb62s83-HCl4LX8KmZcaAP8QjG9TKA">Slack</a></li>
              <li class="nav-item"><a class="nav-link" href="https://github.com/gdg-berlin-android">Github</a></li>
              <li class="nav-item"><a class="nav-link" href="https://goo.gl/forms/LKVnBINiIcyeeEfy2">Propose presentation</a></li>
            </ul>
@@ -70,7 +70,7 @@
               <div class="carousel-caption">
                 <h1>Our co-learning channel</h1>
                 <br>
-                <p><a class="btn btn-lg btn-primary" href="https://join.slack.com/t/adg-berlin/shared_invite/zt-1j6f5y2oh-A3Xf1VDTKDOTf55Ti_H5~g" role="button">Learn more</a></p>
+                <p><a class="btn btn-lg btn-primary" href="https://join.slack.com/t/adg-berlin/shared_invite/zt-20sb62s83-HCl4LX8KmZcaAP8QjG9TKA" role="button">Learn more</a></p>
               </div>
             </div>
           </div>
@@ -119,7 +119,7 @@
               <br><u>- beginners:</u> come by and ask us any question you have. We will help you regardless it is installing AndroidStudio or making VR app;
               <br><u>- experienced:</u> come by and share your knowledge and help our new Android fellows or ask questions to other experienced attendees, or just to work on your own projects.
               <br><br>There no strict rule. Just come by and let’s share a good time!
-              <br><br>We encourage you to join our Slack group “Android Developer Group Berlin”. Use our <a href="https://join.slack.com/t/adg-berlin/shared_invite/zt-1j6f5y2oh-A3Xf1VDTKDOTf55Ti_H5~g">signup link</a> 
+              <br><br>We encourage you to join our Slack group “Android Developer Group Berlin”. Use our <a href="https://join.slack.com/t/adg-berlin/shared_invite/zt-20sb62s83-HCl4LX8KmZcaAP8QjG9TKA">signup link</a> 
               to join, and once on slack you can find #co-learning channel. There all attendees and organizers are encouraged to hang out.</p>
           </div>
           <div class="col-lg-4 section">
@@ -145,7 +145,7 @@
             <div class="col-md-6">
               <h6>Who we are</h6>
               <p class="post-body">We are the Berlin Google Developer Group (GDG) focused on Android development.
-                <br><br> Go <a href="https://join.slack.com/t/adg-berlin/shared_invite/zt-1j6f5y2oh-A3Xf1VDTKDOTf55Ti_H5~g">here</a> to join the Android Developers Group Slack team.
+                <br><br> Go <a href="https://join.slack.com/t/adg-berlin/shared_invite/zt-20sb62s83-HCl4LX8KmZcaAP8QjG9TKA">here</a> to join the Android Developers Group Slack team.
                 <br>To contact the organizers write us an <a href="mailto:gdg-berlin-android-orga@googlegroups.com">email</a>.
               </p>
             </div>
@@ -172,7 +172,7 @@
              <ul>
                <li><a href="https://www.meetup.com/GDG-Berlin-Android/">Events</a></li>
                <li><a href="https://androiddev.social/@berlindroid">Mastodon</a></li>
-               <li><a href="https://join.slack.com/t/adg-berlin/shared_invite/zt-1j6f5y2oh-A3Xf1VDTKDOTf55Ti_H5~g">Slack</a></li>
+               <li><a href="https://join.slack.com/t/adg-berlin/shared_invite/zt-20sb62s83-HCl4LX8KmZcaAP8QjG9TKA">Slack</a></li>
                <li><a href="https://github.com/gdg-berlin-android">Gitub</a></li>
              </ul>
            </div>
@@ -194,7 +194,7 @@
                <li><a class="py-2 d-md-inline-block" href="https://androiddev.social/@berlindroid" rel="me"><i class="fab fa-mastodon fa-lg"></i></a></li>
                <li><a class="py-2 d-md-inline-block" href="https://www.meetup.com/GDG-Berlin-Android/"><i class="fab fa-meetup fa-lg"></i></a></li>
                <li><a class="py-2 d-md-inline-block" href="https://github.com/gdg-berlin-android"><i class="fab fa-github fa-lg"></i></a></li>
-               <li><a class="py-2 d-md-inline-block" href="https://join.slack.com/t/adg-berlin/shared_invite/zt-1j6f5y2oh-A3Xf1VDTKDOTf55Ti_H5~g"><i class="fab fa-slack-hash fa-lg"></i></a></li>
+               <li><a class="py-2 d-md-inline-block" href="https://join.slack.com/t/adg-berlin/shared_invite/zt-20sb62s83-HCl4LX8KmZcaAP8QjG9TKA"><i class="fab fa-slack-hash fa-lg"></i></a></li>
              </ul>
            </div>
          </div>


### PR DESCRIPTION
Update slack signup link as the `never expire` link expires after 400 invites, other options are not possible due to security reasons.

To create the next link after this one expires:
invite people to slack -> create 30 day link -> adjust the expiration date to never expire.

https://join.slack.com/t/adg-berlin/shared_invite/zt-20sb62s83-HCl4LX8KmZcaAP8QjG9TKA

<img width="653" alt="Screenshot 2023-08-07 at 22 07 46" src="https://github.com/annamorgiel/gdg-berlin-android.github.io/assets/18116883/7feff907-dedf-4be9-af85-8ea55d509ac1">


<img width="635" alt="Screenshot 2023-08-07 at 22 01 06" src="https://github.com/annamorgiel/gdg-berlin-android.github.io/assets/18116883/0129a825-ccb4-487a-9303-5dfdd7a8ad17">
